### PR TITLE
Add useMessageCount hook backed by service container

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { PollingService } from "./services/Polling.service";
 import { usePackageManager } from "./hooks/usePackageManager";
 import { useAccount, useNetwork } from 'wagmi';
 import useIDB from "./hooks/useIDB";
+import { useMessageCount } from "./hooks/useMessageCount";
 
 export default function App() {
   // Reload app UI when wallet account or chain changes (RainbowKit/wagmi)
@@ -87,6 +88,7 @@ export default function App() {
   };
 
   const { ready: idbReady, error: idbError } = useIDB();
+  const { setMessageCount } = useMessageCount();
 
   useEffect(() => {
     if (!idbReady) return;
@@ -213,7 +215,7 @@ export default function App() {
       ]);
 
       enqueueSnackbar(`Ownable successfully loaded`, { variant: "success" });
-      LocalStorageService.remove("messageCount");
+      await setMessageCount(0);
       setMessages(0);
 
       // Trigger a refresh only for updated ownables

--- a/src/components/ViewMessagesBar.tsx
+++ b/src/components/ViewMessagesBar.tsx
@@ -18,7 +18,8 @@ import { EventChain } from "eqty-core";
 import { enqueueSnackbar } from "notistack";
 import LocalStorageService from "../services/LocalStorage.service";
 import placeholderImage from "../assets/cube.png";
-import PackageService from "../services/Package.service"
+import PackageService from "../services/Package.service";
+import { useMessageCount } from "../hooks/useMessageCount";
 
 interface ViewMessagesBarProps {
   open: boolean;
@@ -79,6 +80,7 @@ export const ViewMessagesBar: React.FC<ViewMessagesBarProps> = ({
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(50);
   const [totalCount, setTotalCount] = useState(0);
+  const { decrementMessageCount } = useMessageCount();
 
   const fetchBuilderAddress = async () => {
     try {
@@ -156,9 +158,7 @@ export const ViewMessagesBar: React.FC<ViewMessagesBarProps> = ({
 
           // Update imported hashes
           setImportedHashes((prev) => new Set(prev).add(hash));
-          const messageCount = await LocalStorageService.get("messageCount");
-          const newCount = Math.max(0, parseInt(messageCount || "0", 10) - 1);
-          await LocalStorageService.set("messageCount", newCount);
+          await decrementMessageCount();
           enqueueSnackbar(`Ownable imported successfully!`, {
             variant: "success",
           });

--- a/src/hooks/useMessageCount.ts
+++ b/src/hooks/useMessageCount.ts
@@ -1,0 +1,65 @@
+import { useCallback, useMemo } from "react";
+import { useContainer } from "../contexts/Services.context";
+import LocalStorageService from "../services/LocalStorage.service";
+
+const MESSAGE_COUNT_KEY = "messageCount";
+
+const normalizeCount = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, value);
+  }
+
+  const parsed = parseInt(String(value ?? "0"), 10);
+  if (Number.isNaN(parsed)) {
+    return 0;
+  }
+
+  return Math.max(0, parsed);
+};
+
+export interface UseMessageCountResult {
+  getMessageCount: () => Promise<number>;
+  setMessageCount: (count: number) => Promise<void>;
+  decrementMessageCount: () => Promise<number>;
+}
+
+export const useMessageCount = (): UseMessageCountResult => {
+  const container = useContainer();
+  const localStorageService = useMemo(
+    () => container.get<LocalStorageService>("localStorage"),
+    [container]
+  );
+
+  const getMessageCount = useCallback(async (): Promise<number> => {
+    const stored = await Promise.resolve(
+      localStorageService.get(MESSAGE_COUNT_KEY)
+    );
+
+    return normalizeCount(stored);
+  }, [localStorageService]);
+
+  const setMessageCount = useCallback(
+    async (count: number): Promise<void> => {
+      const normalized = normalizeCount(count);
+      await Promise.resolve(
+        localStorageService.set(MESSAGE_COUNT_KEY, normalized)
+      );
+    },
+    [localStorageService]
+  );
+
+  const decrementMessageCount = useCallback(async (): Promise<number> => {
+    const current = await getMessageCount();
+    const next = Math.max(0, current - 1);
+    await setMessageCount(next);
+    return next;
+  }, [getMessageCount, setMessageCount]);
+
+  return {
+    getMessageCount,
+    setMessageCount,
+    decrementMessageCount,
+  };
+};
+
+export default useMessageCount;

--- a/src/services/ServiceContainer.ts
+++ b/src/services/ServiceContainer.ts
@@ -20,11 +20,15 @@ export default class ServiceContainer {
 
   constructor(public readonly address?: string, public readonly chainId?: number) {
     this.register('relay', (c) => new RelayService());
+    this.register('localStorage', (c) => {
+      if (c.address && c.chainId) return new LocalStorageService(`${c.chainId}:${c.address}`);
+      if (c.address) return new LocalStorageService(`${c.address}`);
+      return new LocalStorageService();
+    });
 
     if (address && chainId) {
       this.register('eqty', (c) => new EQTYService(c.address!, c.chainId!));
       this.register('idb', (c) => new IDBService(`${c.chainId}:${c.address}`));
-      this.register('localStorage', (c) => new LocalStorageService(`${c.chainId}:${c.address}`));
       this.register('eventChains', (c) => new EventChainService(c.get('idb'), c.get('eqty')));
       this.register('packages', (c) => new PackageService(c.get('relay'), c.get('localStorage')));
       this.register('ownables', (c) => new OwnableService(c.get('eventChains'), c.get('eqty'), c.get('packages')));


### PR DESCRIPTION
## Summary
- add a useMessageCount hook that retrieves the LocalStorageService from the service container and exposes helpers to manage the unread count
- update ViewMessagesBar and App to rely on the new hook instead of calling the storage service directly for message count changes
- ensure the LocalStorageService is registered on the service container even when a chain id is not yet available

## Testing
- CI=true npm test -- --watch=false *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb1f6ee088320838009c33d4d3d45